### PR TITLE
Fix ENG-3650 - characters in procedure names

### DIFF
--- a/VoltDB.Data.Client/Connections/ProcedureAccess.cs
+++ b/VoltDB.Data.Client/Connections/ProcedureAccess.cs
@@ -51,7 +51,7 @@ namespace VoltDB.Data.Client
         /// Regular expression used to validate tokens (procedure names only for now) (will make sure the name doesn't
         /// have any @ sign, or other invalid character for that matter).
         /// </summary>
-        private Regex TokenValidator = new Regex("^[a-zA-Z0-9_]*$");
+        private Regex TokenValidator = new Regex("^[a-zA-Z0-9_.$@]*$");
         
         /// <summary>
         /// Validate the procedure name (alpahnumeric only, no @)

--- a/VoltDB.Data.Client/Connections/ProcedureWrapper[T].tt
+++ b/VoltDB.Data.Client/Connections/ProcedureWrapper[T].tt
@@ -261,7 +261,7 @@ namespace VoltDB.Data.Client
         /// Regular expression used to validate tokens (procedure names only for now) (will make sure the name doesn't
         /// have any @ sign, or other invalid character for that matter).
         /// </summary>
-        private Regex TokenValidator = new Regex("^[a-zA-Z0-9_]*$");
+        private Regex TokenValidator = new Regex("^[a-zA-Z0-9_.$@]*$");
         
         /// <summary>
         /// Validate the procedure name (alpahnumeric only, no @)


### PR DESCRIPTION
Allow alphanumeric, underscore, dollar, period, and at sign. DDLCompiler uses "([\w.$]+)" to match. I allowed @ to allow users to use new system procedures without updating the client library.
