### PR TITLE
Fix datetime UTC conversions (ENG-4019)

### DIFF
--- a/VoltDB.Data.Client/Protocol/Serializer.cs
+++ b/VoltDB.Data.Client/Protocol/Serializer.cs
@@ -548,7 +548,8 @@ namespace VoltDB.Data.Client
         /// <returns>The serializer instance, ready to chain the next command.</returns>
         public Serializer Write(DateTime value)
         {
-            Cnv.PutBytes(_tempBuffer, 0, (((DateTime)value).ToUniversalTime().Ticks - VoltType.TIMESTAMP_ORIGIN) / 10L);
+            if (value.Kind == DateTimeKind.Local) value = value.ToUniversalTime();
+            Cnv.PutBytes(_tempBuffer, 0, (value.Ticks - VoltType.TIMESTAMP_ORIGIN) / 10L);
             writer.Write(_tempBuffer, 0, 8);
             return this;
         }


### PR DESCRIPTION
Previous behaviour assumed unspecified datetimes were local, and converted to UTC. That means most simple datetimes would not roundtrip. New code assumes UTC datetimes, unless explicitly specified as local. 

Apps should pass UTC dates in general. If they need local times, they need to store a separate field with offset information and handle conversions in app code.
