### PR TITLE
Single Object[] Param Handling

### DIFF
--- a/VoltDB.Data.Client/Connections/VoltNodeConnection.cs
+++ b/VoltDB.Data.Client/Connections/VoltNodeConnection.cs
@@ -178,7 +178,7 @@ namespace VoltDB.Data.Client
                 // This might fail (invalid parameters / exceeding max string length, for instance) - the equivalent of an
                 // ArgumentException, so we leave it outside of the try/catch block related to protecting ourselves against
                 // connectivity issues.
-                if (parameters.Length == 1 && parameters[0] is Array)
+                if (parameters.Length == 1 && parameters[0] is Array && parameters[0].GetType() == typeof(object[]))
                 {
                     parameters = (object[]) parameters[0];
                     for (int i = 0; i < parameters.Length; i++)


### PR DESCRIPTION
An object array parameter used to get pushed out as object from
CoalesceNull and this caused the Unsupported Type Exception. This
change verifies for a single param array and calls CoalesceNull on each
individual element of the array.
