### PR TITLE
Memory leak may happen, when calculated min thread.

### DIFF
--- a/VoltDB.Data.Client/Connections/Internal/CallbackExecutor.cs
+++ b/VoltDB.Data.Client/Connections/Internal/CallbackExecutor.cs
@@ -110,7 +110,11 @@ namespace VoltDB.Data.Client
                 // calculation)
                 int workerThreads;
                 int completionPortThreads;
-                ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
+                // **** the no. of worker thread shall be the no. of processors and not the minimum no. of threads of pool.
+                // ThreadPool.GetMinThreads(out workerThreads, out completionPortThreads);
+                workerThreads = Environment.ProcessorCount;
+                completionPortThreads = Environment.ProcessorCount;
+                
                 int processingThreadCount = Math.Max(workerThreads - 3, 2); // -3 is for: 1 Client thread + at least 2 connection threads.
                 Threads = new Thread[processingThreadCount];
 


### PR DESCRIPTION
There may be other application using the dll - min thread is not the no. of CPUs, as the code means.
Whether min no. of threads is big (>100 or even less), there may be memory leak.

The no. of CPUs is more correct, and not causing memory leak.
Hence, change the code of : ThreadPool.GetMinThread( ...) to:
workerThreads = Environment.ProcessorCount;
completionPortThreads = Environment.ProcessorCount;